### PR TITLE
fragment size adjustment in preset via API

### DIFF
--- a/webapps/api/backend/views/albabackends.py
+++ b/webapps/api/backend/views/albabackends.py
@@ -160,7 +160,7 @@ class AlbaBackendViewSet(viewsets.ViewSet):
     @required_roles(['read', 'write', 'manage'])
     @return_task()
     @load(AlbaBackend, validator=validate_access)
-    def add_preset(self, albabackend, name, compression, policies, encryption):
+    def add_preset(self, albabackend, name, compression, policies, encryption, fragment_size=None):
         """
         Adds a preset to a backend
         :param albabackend: ALBA backend to add preset for
@@ -168,8 +168,9 @@ class AlbaBackendViewSet(viewsets.ViewSet):
         :param compression: Compression type
         :param policies: Policies linked to the preset
         :param encryption: Encryption type
+        :param fragment_size: Size of a fragment in bytes
         """
-        return AlbaController.add_preset.delay(albabackend.guid, name, compression, policies, encryption)
+        return AlbaController.add_preset.delay(albabackend.guid, name, compression, policies, encryption, fragment_size)
 
     @action()
     @log()


### PR DESCRIPTION
As part 1 for #204: integration of fragment size adjustment in API

Validated with integration testing:
```
{u'compression': u'snappy',
  u'fragment_checksum': [u'crc-32c'],
  u'fragment_encryption': [u'none'],
  u'fragment_size': 2097152, <---------------------------------------
  u'in_use': False,
  u'is_available': False,
  u'is_default': False,
  u'name': u'mypreset',
  u'object_checksum': {u'allowed': [[u'none'], [u'sha-1'], [u'crc-32c']],
   u'default': [u'crc-32c'],
   u'verify_upload': True},
  u'osds': [u'all'],
  u'policies': [u'(2, 2, 3, 4)'],
  u'policy_metadata': {u'(2, 2, 3, 4)': {u'in_use': False,
    u'is_active': False,
    u'is_available': False}}}]
```