### PR TITLE
patch #294

### DIFF
--- a/ovs/extensions/plugins/albacli.py
+++ b/ovs/extensions/plugins/albacli.py
@@ -31,7 +31,7 @@ class AlbaCLI(object):
     Wrapper for 'alba' command line interface
     """
     @staticmethod
-    def run(command, config, named_params=None, extra_params=None, client=None, debug=False):
+    def run(command, config=None, named_params=None, extra_params=None, client=None, debug=False):
         """
         Executes a command on ALBA
         When --to-json is NOT passed:
@@ -73,7 +73,9 @@ class AlbaCLI(object):
 
         debug_log = []
         try:
-            cmd_list = ['/usr/bin/alba', command, '--config={0}'.format(config), '--to-json']
+            cmd_list = ['/usr/bin/alba', command, '--to-json']
+            if config is not None:
+                cmd_list.append('--config={0}'.format(config))
             for key, value in named_params.iteritems():
                 cmd_list.append('--{0}={1}'.format(key, value))
             cmd_list.extend(extra_params)


### PR DESCRIPTION
#294

Previously:
```
In [2]: AlbaCLI.run(command="proxy-client-cfg", named_params={'host':'10.100.199.181', 'port':26204})
---------------------------------------------------------------------------
TypeError                                 Traceback (most recent call last)
<ipython-input-2-ce3de7dd4017> in <module>()
----> 1 AlbaCLI.run(command="proxy-client-cfg", named_params={'host':'10.100.199.181', 'port':26204})

TypeError: run() takes at least 2 arguments (2 given)
```

Result:
```
In [4]: AlbaCLI.run(command="proxy-client-cfg", named_params={'host':'10.100.199.181', 'port':26204})
Out[4]: 
{u'cluster_id': u'mybackend-global-abm',
 u'node_cfgs': [[u'13covJSpGv7lptDY',
   {u'ips': [u'10.100.199.182'], u'port': 26412}],
  [u'Qeu0onUPO6odaG6o', {u'ips': [u'10.100.199.183'], u'port': 26412}],
  [u'jzA6kKHAKuHMcyLl', {u'ips': [u'10.100.199.181'], u'port': 26412}]],
 u'ssl_cfg': None,
 u'tcp_keepalive': {u'enable_tcp_keepalive': True,
  u'tcp_keepalive_intvl': 20,
  u'tcp_keepalive_probes': 3,
  u'tcp_keepalive_time': 20}}

```