### PR TITLE
Fixed an issue in the ensure single decorator

### DIFF
--- a/ovs/lib/alba.py
+++ b/ovs/lib/alba.py
@@ -366,7 +366,9 @@ class AlbaController(object):
         return config.export()
 
     @staticmethod
-    @ovs_task(name='alba.scheduled_alba_arakoon_checkup', schedule=Schedule(minute='30', hour='*'), ensure_single_info={'mode': 'DEFAULT'})
+    @ovs_task(name='alba.scheduled_alba_arakoon_checkup',
+              schedule=Schedule(minute='30', hour='*'),
+              ensure_single_info={'mode': 'DEFAULT', 'extra_task_names': ['alba.manual_alba_arakoon_checkup']})
     def scheduled_alba_arakoon_checkup():
         """
         Makes sure the volumedriver Arakoon is on all available master nodes
@@ -375,7 +377,8 @@ class AlbaController(object):
         AlbaController._alba_arakoon_checkup()
 
     @staticmethod
-    @ovs_task(name='alba.manual_alba_arakoon_checkup', ensure_single_info={'mode': 'DEFAULT'})
+    @ovs_task(name='alba.manual_alba_arakoon_checkup',
+              ensure_single_info={'mode': 'DEFAULT', 'extra_task_names': ['alba.scheduled_alba_arakoon_checkup']})
     def manual_alba_arakoon_checkup(alba_backend_guid, nsm_clusters, abm_cluster=None):
         """
         Creates a new Arakoon cluster if required and extends cluster if possible on all available master nodes

--- a/ovs/lib/alba.py
+++ b/ovs/lib/alba.py
@@ -27,7 +27,6 @@ import datetime
 import requests
 from ConfigParser import RawConfigParser
 from StringIO import StringIO
-from ovs.celery_run import celery
 from ovs.dal.exceptions import ObjectNotFoundException
 from ovs.dal.hybrids.albaabmcluster import ABMCluster
 from ovs.dal.hybrids.albabackend import AlbaBackend
@@ -50,7 +49,7 @@ from ovs.extensions.db.arakoon.ArakoonInstaller import ArakoonClusterConfig, Ara
 from ovs.extensions.generic.configuration import Configuration, NotFoundException
 from ovs.extensions.generic.sshclient import SSHClient, UnableToConnectException
 from ovs.extensions.plugins.albacli import AlbaCLI
-from ovs.lib.helpers.decorators import add_hooks, ensure_single
+from ovs.lib.helpers.decorators import add_hooks, ovs_task
 from ovs.lib.helpers.toolbox import Schedule, Toolbox
 from ovs.log.log_handler import LogHandler
 
@@ -71,7 +70,7 @@ class AlbaController(object):
     _logger = LogHandler.get('lib', name='alba')
 
     @staticmethod
-    @celery.task(name='alba.add_units')
+    @ovs_task(name='alba.add_units')
     def add_units(alba_backend_guid, osds, metadata=None):
         """
         Adds storage units to an Alba Backend
@@ -140,7 +139,7 @@ class AlbaController(object):
         return unclaimed_osds
 
     @staticmethod
-    @celery.task(name='alba.remove_units')
+    @ovs_task(name='alba.remove_units')
     def remove_units(alba_backend_guid, osd_ids):
         """
         Removes storage units from an Alba Backend
@@ -171,7 +170,7 @@ class AlbaController(object):
             raise RuntimeError('Error processing one or more OSDs: {0}'.format(failed_osds))
 
     @staticmethod
-    @celery.task(name='alba.add_cluster')
+    @ovs_task(name='alba.add_cluster')
     def add_cluster(alba_backend_guid, abm_cluster=None, nsm_clusters=None):
         """
         Adds an Arakoon cluster to service Backend
@@ -230,7 +229,7 @@ class AlbaController(object):
         alba_backend.invalidate_dynamics('live_status')
 
     @staticmethod
-    @celery.task(name='alba.remove_cluster')
+    @ovs_task(name='alba.remove_cluster')
     def remove_cluster(alba_backend_guid):
         """
         Removes an Alba Backend/cluster
@@ -337,7 +336,7 @@ class AlbaController(object):
         backend.delete()
 
     @staticmethod
-    @celery.task(name='alba.get_arakoon_config')
+    @ovs_task(name='alba.get_arakoon_config')
     def get_arakoon_config(alba_backend_guid):
         """
         Gets the Arakoon configuration for an Alba Backend
@@ -367,7 +366,7 @@ class AlbaController(object):
         return config.export()
 
     @staticmethod
-    @celery.task(name='alba.scheduled_alba_arakoon_checkup', schedule=Schedule(minute='30', hour='*'), bind=True)
+    @ovs_task(name='alba.scheduled_alba_arakoon_checkup', schedule=Schedule(minute='30', hour='*'), ensure_single_info={'mode': 'DEFAULT'})
     def scheduled_alba_arakoon_checkup():
         """
         Makes sure the volumedriver Arakoon is on all available master nodes
@@ -376,7 +375,7 @@ class AlbaController(object):
         AlbaController._alba_arakoon_checkup()
 
     @staticmethod
-    @celery.task(name='alba.manual_alba_arakoon_checkup', bind=True)
+    @ovs_task(name='alba.manual_alba_arakoon_checkup', ensure_single_info={'mode': 'DEFAULT'})
     def manual_alba_arakoon_checkup(alba_backend_guid, nsm_clusters, abm_cluster=None):
         """
         Creates a new Arakoon cluster if required and extends cluster if possible on all available master nodes
@@ -423,7 +422,6 @@ class AlbaController(object):
             client.run(['ln', '-s', '{0}/{1}.cmxs'.format(AlbaController.ARAKOON_PLUGIN_DIR, plugin), '{0}/arakoon/{1}/db'.format(data_dir, cluster_name)])
 
     @staticmethod
-    @ensure_single(task_name='alba.alba_arakoon_checkup')
     def _alba_arakoon_checkup(alba_backend_guid=None, abm_cluster=None, nsm_clusters=None):
         slaves = StorageRouterList.get_slaves()
         masters = StorageRouterList.get_masters()
@@ -741,8 +739,7 @@ class AlbaController(object):
                 'question': '\n'.join(sorted(messages)) + '\nAre you sure you want to continue?'}
 
     @staticmethod
-    @celery.task(name='alba.nsm_checkup', schedule=Schedule(minute='45', hour='*'), bind=True)
-    @ensure_single(task_name='alba.nsm_checkup', mode='CHAINED')
+    @ovs_task(name='alba.nsm_checkup', schedule=Schedule(minute='45', hour='*'), ensure_single_info={'mode': 'CHAINED'})
     def nsm_checkup(allow_offline=False, alba_backend_guid=None, min_nsms=1, additional_nsms=None):
         """
         Validates the current NSM setup/configuration and takes actions where required.
@@ -999,7 +996,7 @@ class AlbaController(object):
             raise RuntimeError('Checking NSM failed for ALBA backends: {0}'.format(', '.join(failed_backends)))
 
     @staticmethod
-    @celery.task(name='alba.calculate_safety')
+    @ovs_task(name='alba.calculate_safety')
     def calculate_safety(alba_backend_guid, removal_osd_ids):
         """
         Calculates/loads the safety when a certain set of disks are removed
@@ -1210,7 +1207,7 @@ class AlbaController(object):
                 Configuration.set(key.format(machine_id), 9)
 
     @staticmethod
-    @celery.task(name='alba.link_alba_backends')
+    @ovs_task(name='alba.link_alba_backends')
     def link_alba_backends(alba_backend_guid, metadata):
         """
         Link a GLOBAL ALBA Backend to a LOCAL or another GLOBAL ALBA Backend
@@ -1290,7 +1287,7 @@ class AlbaController(object):
         return True
 
     @staticmethod
-    @celery.task(name='alba.unlink_alba_backends')
+    @ovs_task(name='alba.unlink_alba_backends')
     def unlink_alba_backends(target_guid, linked_guid):
         """
         Unlink a LOCAL or GLOBAL ALBA Backend from a GLOBAL ALBA Backend
@@ -1314,8 +1311,7 @@ class AlbaController(object):
         parent.backend.invalidate_dynamics()
 
     @staticmethod
-    @celery.task(name='alba.checkup_maintenance_agents', schedule=Schedule(minute='0', hour='*'), bind=True)
-    @ensure_single(task_name='alba.checkup_maintenance_agents', mode='CHAINED')
+    @ovs_task(name='alba.checkup_maintenance_agents', schedule=Schedule(minute='0', hour='*'), ensure_single_info={'mode': 'CHAINED'})
     def checkup_maintenance_agents():
         """
         Check if requested nr of maintenance agents / Backend is actually present
@@ -1493,7 +1489,7 @@ class AlbaController(object):
             AlbaController._logger.info('Finished service work log for {0}'.format(name))
 
     @staticmethod
-    @celery.task(name='alba.verify_namespaces', schedule=Schedule(minute='0', hour='0', day_of_month='1', month_of_year='*/3'))
+    @ovs_task(name='alba.verify_namespaces', schedule=Schedule(minute='0', hour='0', day_of_month='1', month_of_year='*/3'))
     def verify_namespaces():
         """
         Verify namespaces for all backends

--- a/ovs/lib/alba.py
+++ b/ovs/lib/alba.py
@@ -367,7 +367,7 @@ class AlbaController(object):
         return config.export()
 
     @staticmethod
-    @celery.task(name='alba.scheduled_alba_arakoon_checkup', schedule=Schedule(minute='30', hour='*'))
+    @celery.task(name='alba.scheduled_alba_arakoon_checkup', schedule=Schedule(minute='30', hour='*'), bind=True)
     def scheduled_alba_arakoon_checkup():
         """
         Makes sure the volumedriver Arakoon is on all available master nodes
@@ -376,7 +376,7 @@ class AlbaController(object):
         AlbaController._alba_arakoon_checkup()
 
     @staticmethod
-    @celery.task(name='alba.manual_alba_arakoon_checkup')
+    @celery.task(name='alba.manual_alba_arakoon_checkup', bind=True)
     def manual_alba_arakoon_checkup(alba_backend_guid, nsm_clusters, abm_cluster=None):
         """
         Creates a new Arakoon cluster if required and extends cluster if possible on all available master nodes
@@ -741,7 +741,7 @@ class AlbaController(object):
                 'question': '\n'.join(sorted(messages)) + '\nAre you sure you want to continue?'}
 
     @staticmethod
-    @celery.task(name='alba.nsm_checkup', schedule=Schedule(minute='45', hour='*'))
+    @celery.task(name='alba.nsm_checkup', schedule=Schedule(minute='45', hour='*'), bind=True)
     @ensure_single(task_name='alba.nsm_checkup', mode='CHAINED')
     def nsm_checkup(allow_offline=False, alba_backend_guid=None, min_nsms=1, additional_nsms=None):
         """
@@ -1314,7 +1314,7 @@ class AlbaController(object):
         parent.backend.invalidate_dynamics()
 
     @staticmethod
-    @celery.task(name='alba.checkup_maintenance_agents', schedule=Schedule(minute='0', hour='*'))
+    @celery.task(name='alba.checkup_maintenance_agents', schedule=Schedule(minute='0', hour='*'), bind=True)
     @ensure_single(task_name='alba.checkup_maintenance_agents', mode='CHAINED')
     def checkup_maintenance_agents():
         """

--- a/ovs/lib/albanode.py
+++ b/ovs/lib/albanode.py
@@ -19,9 +19,8 @@ AlbaNodeController module
 """
 
 import requests
-from ovs.celery_run import celery
-from ovs.dal.hybrids.albanode import AlbaNode
 from ovs.dal.hybrids.albadisk import AlbaDisk
+from ovs.dal.hybrids.albanode import AlbaNode
 from ovs.dal.hybrids.diskpartition import DiskPartition
 from ovs.dal.hybrids.storagerouter import StorageRouter
 from ovs.dal.lists.albabackendlist import AlbaBackendList
@@ -31,11 +30,10 @@ from ovs.dal.lists.storagerouterlist import StorageRouterList
 from ovs.extensions.generic.configuration import Configuration
 from ovs.extensions.generic.sshclient import SSHClient
 from ovs.extensions.plugins.asdmanager import InvalidCredentialsError
-from ovs.log.log_handler import LogHandler
 from ovs.lib.alba import AlbaController
 from ovs.lib.disk import DiskController
-from ovs.lib.helpers.decorators import add_hooks
-from ovs.lib.helpers.decorators import ensure_single
+from ovs.lib.helpers.decorators import add_hooks, ovs_task
+from ovs.log.log_handler import LogHandler
 
 
 class AlbaNodeController(object):
@@ -47,7 +45,7 @@ class AlbaNodeController(object):
     ASD_CONFIG = '{0}/config'.format(ASD_CONFIG_DIR)
 
     @staticmethod
-    @celery.task(name='albanode.register')
+    @ovs_task(name='albanode.register')
     def register(node_id):
         """
         Adds a Node with a given node_id to the model
@@ -77,7 +75,7 @@ class AlbaNodeController(object):
         AlbaController.checkup_maintenance_agents.delay()
 
     @staticmethod
-    @celery.task(name='albanode.remove_node')
+    @ovs_task(name='albanode.remove_node')
     def remove_node(node_guid):
         """
         Removes an ALBA node
@@ -107,7 +105,7 @@ class AlbaNodeController(object):
         AlbaController.checkup_maintenance_agents.delay()
 
     @staticmethod
-    @celery.task(name='albanode.replace_node')
+    @ovs_task(name='albanode.replace_node')
     def replace_node(old_node_guid, new_node_id):
         """
         Replace an ALBA node
@@ -122,7 +120,7 @@ class AlbaNodeController(object):
         AlbaNodeController.register(node_id=new_node_id)
 
     @staticmethod
-    @celery.task(name='albanode.initialize_disk')
+    @ovs_task(name='albanode.initialize_disk')
     def initialize_disks(node_guid, disks):
         """
         Initializes 1 or multiple disks
@@ -183,8 +181,7 @@ class AlbaNodeController(object):
         return failures
 
     @staticmethod
-    @celery.task(name='albanode.remove_disk', bind=True)
-    @ensure_single(task_name='albanode.remove_disk', mode='CHAINED')
+    @ovs_task(name='albanode.remove_disk', ensure_single_info={'mode': 'CHAINED'})
     def remove_disk(node_guid, device_alias):
         """
         Removes a disk
@@ -251,8 +248,7 @@ class AlbaNodeController(object):
             DiskController.sync_with_reality(storagerouter_guid=node.storagerouter_guid)
 
     @staticmethod
-    @celery.task(name='albanode.remove_asd', bind=True)
-    @ensure_single(task_name='albanode.remove_asd', mode='CHAINED')
+    @ovs_task(name='albanode.remove_asd', ensure_single_info={'mode': 'CHAINED'})
     def remove_asd(node_guid, asd_id, expected_safety):
         """
         Removes an ASD
@@ -345,7 +341,7 @@ class AlbaNodeController(object):
         return [] if disk_data is None else disk_data.get('aliases', [])
 
     @staticmethod
-    @celery.task(name='albanode.reset_asd')
+    @ovs_task(name='albanode.reset_asd')
     def reset_asd(node_guid, asd_id, expected_safety):
         """
         Removes and re-adds an ASD to a Disk
@@ -373,7 +369,7 @@ class AlbaNodeController(object):
             AlbaNodeController._logger.warning('Could not connect to node {0} to (re)configure ASD'.format(node.guid))
 
     @staticmethod
-    @celery.task(name='albanode.restart_asd')
+    @ovs_task(name='albanode.restart_asd')
     def restart_asd(node_guid, asd_id):
         """
         Restarts an ASD on a given Node
@@ -414,7 +410,7 @@ class AlbaNodeController(object):
             raise RuntimeError(result['_error'])
 
     @staticmethod
-    @celery.task(name='albanode.restart_disk')
+    @ovs_task(name='albanode.restart_disk')
     def restart_disk(node_guid, device_alias):
         """
         Restarts a disk
@@ -470,7 +466,7 @@ class AlbaNodeController(object):
                 node.save()
 
     @staticmethod
-    @celery.task(name='albanode.get_logfiles')
+    @ovs_task(name='albanode.get_logfiles')
     def get_logfiles(albanode_guid, local_storagerouter_guid):
         """
         Collects logs, moves them to a web-accessible location and returns log tgz's filename

--- a/ovs/lib/albapreset.py
+++ b/ovs/lib/albapreset.py
@@ -23,10 +23,10 @@ import re
 import json
 import random
 import tempfile
-from ovs.celery_run import celery
 from ovs.dal.hybrids.albabackend import AlbaBackend
 from ovs.extensions.generic.configuration import Configuration
 from ovs.extensions.plugins.albacli import AlbaCLI
+from ovs.lib.helpers.decorators import ovs_task
 from ovs.lib.helpers.toolbox import Toolbox
 from ovs.log.log_handler import LogHandler
 
@@ -38,7 +38,7 @@ class AlbaPresetController(object):
     _logger = LogHandler.get('lib', name='albapreset')
 
     @staticmethod
-    @celery.task(name='alba.add_preset')
+    @ovs_task(name='alba.add_preset')
     def add_preset(alba_backend_guid, name, compression, policies, encryption, fragment_size=None):
         """
         Adds a preset to Alba
@@ -118,7 +118,7 @@ class AlbaPresetController(object):
                 os.remove(filename)
 
     @staticmethod
-    @celery.task(name='albapreset.delete_preset')
+    @ovs_task(name='albapreset.delete_preset')
     def delete_preset(alba_backend_guid, name):
         """
         Deletes a preset from the Alba backend
@@ -145,7 +145,7 @@ class AlbaPresetController(object):
         alba_backend.invalidate_dynamics()
 
     @staticmethod
-    @celery.task(name='albapreset.update_preset')
+    @ovs_task(name='albapreset.update_preset')
     def update_preset(alba_backend_guid, name, policies):
         """
         Updates policies for an existing preset to Alba

--- a/webapps/frontend/app/viewmodels/site/backend-alba-detail.js
+++ b/webapps/frontend/app/viewmodels/site/backend-alba-detail.js
@@ -193,6 +193,15 @@ define([
                                         }
                                     }
                                 });
+                                oArray.sort(function(a, b) {
+                                    if (a.storageRouter() !== undefined && b.storageRouter() !== undefined) {
+                                        return a.storageRouter().name() < b.storageRouter().name() ? -1 : 1;
+                                    }
+                                    if (a.storageRouter() === undefined && b.storageRouter() === undefined) {
+                                        return generic.ipSort(a.ip(), b.ip());
+                                    }
+                                    return a.storageRouter() !== undefined ? -1 : 1;
+                                });
                                 if (discover) {
                                     self.dNodesLoading(false);
                                 } else {

--- a/webapps/frontend/app/viewmodels/wizards/addalbanode/confirm.js
+++ b/webapps/frontend/app/viewmodels/wizards/addalbanode/confirm.js
@@ -56,7 +56,7 @@ define([
                                 $.t('alba:wizards.add_alba_node.failed', {why: error})
                             );
                         });
-                    // Replace ALBA node
+                // Replace ALBA node
                 } else {
                     $.each(self.data.oldNode().disks(), function(index, disk) {
                         disk.processing(true);


### PR DESCRIPTION
Eg: 3 tasks shortly after eachother launched (inline), so executed by 3 workers
Task 1 starts processing, task 2 is put on the queue, task 3 was discarded
However task 3 relies on the changes Task 1 or task 2 should do, but since its discarded, it returned immediately
So the fix includes waiting for task 1 & task 2 in case its an inline task

Also made some optimizations in GUI