### PR TITLE
#1575 - Concurrent vPool creation

### DIFF
--- a/ovs/dal/hybrids/albabackend.py
+++ b/ovs/dal/hybrids/albabackend.py
@@ -555,7 +555,7 @@ class AlbaBackend(DataObject):
         for service_name, node in services_for_this_backend.iteritems():
             try:
                 service_status = node.client.get_service_status(name=service_name)
-                if service_status is None or service_status[0] is False:
+                if service_status is None or service_status != 'active':
                     return 'failure'
             except:
                 pass


### PR DESCRIPTION
Changes in ServiceManagement
Start service raises if service is not started properly
Stop service raises if service is not started properly
Get service status only returns the status as returned by systemctl, eg: 'active'