### PR TITLE
Updates can now be performed when only migration changes are required

### DIFF
--- a/ovs/dal/migration/albamigrator.py
+++ b/ovs/dal/migration/albamigrator.py
@@ -20,14 +20,15 @@ ALBA migration module
 
 from ovs.dal.hybrids.backendtype import BackendType
 from ovs.dal.lists.backendtypelist import BackendTypeList
+from ovs_extensions.packages.packagefactory import PackageFactory
 
 
-class ALBAMigrator(object):
+class DALMigrator(object):
     """
     Handles all model related migrations
     """
 
-    identifier = 'alba'
+    identifier = PackageFactory.COMP_MIGRATION_ALBA
     THIS_VERSION = 15
 
     def __init__(self):
@@ -68,7 +69,7 @@ class ALBAMigrator(object):
                 service_type.save()
 
         # From here on, all actual migration should happen to get to the expected state for THIS RELEASE
-        elif working_version < ALBAMigrator.THIS_VERSION:
+        elif working_version < DALMigrator.THIS_VERSION:
             import hashlib
             from ovs.dal.exceptions import ObjectNotFoundException
             from ovs.dal.helpers import HybridRunner, Descriptor
@@ -314,4 +315,4 @@ class ALBAMigrator(object):
                 if '|disks|' in key:
                     client.delete(key=key, must_exist=False)
 
-        return ALBAMigrator.THIS_VERSION
+        return DALMigrator.THIS_VERSION

--- a/ovs/extensions/migration/migration/albamigrator.py
+++ b/ovs/extensions/migration/migration/albamigrator.py
@@ -19,14 +19,15 @@ Alba migration module
 """
 
 from ovs.extensions.generic.logger import Logger
+from ovs_extensions.packages.packagefactory import PackageFactory
 
 
-class AlbaMigrator(object):
+class ExtensionMigrator(object):
     """
     Handles all model related migrations
     """
 
-    identifier = 'alba'  # Used by migrator.py, so don't remove
+    identifier = PackageFactory.COMP_MIGRATION_ALBA
     THIS_VERSION = 12
 
     _logger = Logger('extensions')
@@ -52,13 +53,13 @@ class AlbaMigrator(object):
         working_version = previous_version
 
         # From here on, all actual migration should happen to get to the expected state for THIS RELEASE
-        if working_version < AlbaMigrator.THIS_VERSION:
+        if working_version < ExtensionMigrator.THIS_VERSION:
             try:
                 from ovs.dal.lists.albabackendlist import AlbaBackendList
                 from ovs.extensions.generic.configuration import Configuration, NotFoundException
                 from ovs.lib.alba import AlbaController
 
-                AlbaMigrator._logger.info('Starting migrations...')
+                ExtensionMigrator._logger.info('Starting migrations...')
 
                 # This could be handled by out of band migrations, but since post-update restarts the services,
                 # putting this in the out of band migration code would result in the services being restarted before
@@ -72,8 +73,8 @@ class AlbaMigrator(object):
                         if 'multicast_discover_osds' not in config:
                             config['multicast_discover_osds'] = False
                             Configuration.set(key=config_key, value=config)
-                            AlbaMigrator._logger.info('Updated multi-cast setting for ALBA Backend {0}'.format(alba_backend.name))
-                AlbaMigrator._logger.info('Finished migrations')
+                            ExtensionMigrator._logger.info('Updated multi-cast setting for ALBA Backend {0}'.format(alba_backend.name))
+                ExtensionMigrator._logger.info('Finished migrations')
 
                 if not Configuration.exists(key='/ovs/alba/logging'):
                     try:
@@ -83,8 +84,8 @@ class AlbaMigrator(object):
 
                     Configuration.set(key='/ovs/alba/logging', value=current_logging)
             except:
-                AlbaMigrator._logger.exception('Error occurred while executing the ALBA migration code')
+                ExtensionMigrator._logger.exception('Error occurred while executing the ALBA migration code')
                 # Don't update migration version with latest version, resulting in next migration trying again to execute this code
-                return AlbaMigrator.THIS_VERSION - 1
+                return ExtensionMigrator.THIS_VERSION - 1
 
-        return AlbaMigrator.THIS_VERSION
+        return ExtensionMigrator.THIS_VERSION

--- a/ovs/lib/alba.py
+++ b/ovs/lib/alba.py
@@ -50,6 +50,7 @@ from ovs.extensions.generic.configuration import Configuration, NotFoundExceptio
 from ovs.extensions.generic.logger import Logger
 from ovs.extensions.generic.sshclient import SSHClient, UnableToConnectException
 from ovs_extensions.generic.toolbox import ExtensionsToolbox
+from ovs.extensions.migration.migration.albamigrator import ExtensionMigrator
 from ovs.extensions.packages.albapackagefactory import PackageFactory
 from ovs.extensions.plugins.albacli import AlbaCLI, AlbaError
 from ovs.extensions.storage.volatilefactory import VolatileFactory
@@ -1634,7 +1635,7 @@ class AlbaController(object):
         for storagerouter in StorageRouterList.get_storagerouters():
             machine_id = storagerouter.machine_id
             if not Configuration.exists(key.format(machine_id)):
-                Configuration.set(key.format(machine_id), 9)
+                Configuration.set(key.format(machine_id), ExtensionMigrator.THIS_VERSION)
 
     @staticmethod
     @ovs_task(name='alba.link_alba_backends')

--- a/ovs/lib/albaupdate.py
+++ b/ovs/lib/albaupdate.py
@@ -228,8 +228,8 @@ class AlbaUpdateController(object):
 
                     # DAL migration check
                     if migrations_detected is False:
-                        pf_client = PersistentFactory.get_client()
-                        old_version = pf_client.get('ovs_model_version').get(PackageFactory.COMP_MIGRATION_ALBA) if pf_client.exists('ovs_model_version') else None
+                        persistent_client = PersistentFactory.get_client()
+                        old_version = persistent_client.get('ovs_model_version').get(PackageFactory.COMP_MIGRATION_ALBA) if persistent_client.exists('ovs_model_version') else None
                         if old_version is not None:
                             cls._logger.debug('StorageRouter {0}: Current running version for {1} DAL migrations: {2}'.format(client.ip, PackageFactory.COMP_ALBA, old_version))
                             with remote(client.ip, [DALMigrator]) as rem:


### PR DESCRIPTION
Updates in GUI indicate a migration change only or when only some services need to be restarted