### PR TITLE
Fix constants init

### DIFF
--- a/ovs/constants/albanode.py
+++ b/ovs/constants/albanode.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2018 iNuron NV
+#
+# This file is part of Open vStorage Open Source Edition (OSE),
+# as available from
+#
+#      http://www.openvstorage.org and
+#      http://www.openvstorage.com.
+#
+# This file is free software; you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License v3 (GNU AGPLv3)
+# as published by the Free Software Foundation, in version 3 as it comes
+# in the LICENSE.txt file of the Open vStorage OSE distribution.
+#
+# Open vStorage is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY of any kind.
+
+"""
+Shared albanode constants module
+"""
+
+ASD_CONFIG_DIR = '/ovs/alba/asds/{0}'
+ASD_CONFIG = '{0}/config'.format(ASD_CONFIG_DIR)

--- a/ovs/lib/albanode.py
+++ b/ovs/lib/albanode.py
@@ -36,7 +36,7 @@ from ovs.extensions.generic.sshclient import SSHClient, UnableToConnectException
 from ovs_extensions.generic.toolbox import ExtensionsToolbox
 from ovs.lib.alba import AlbaController
 from ovs.lib.disk import DiskController
-from ovs.lib.shared.albanode import constants
+from ovs.constants.albanode import ASD_CONFIG, ASD_CONFIG_DIR
 from ovs.lib.helpers.decorators import add_hooks, ovs_task
 
 
@@ -280,8 +280,8 @@ class AlbaNodeController(object):
             raise RuntimeError('Error removing OSD: {0}'.format(result['_error']))
 
         # Clean configuration management and model - Well, just try it at least
-        if Configuration.exists(constants.ASD_CONFIG.format(osd_id), raw=True):
-            Configuration.delete(constants.ASD_CONFIG_DIR.format(osd_id), raw=True)
+        if Configuration.exists(ASD_CONFIG.format(osd_id), raw=True):
+            Configuration.delete(ASD_CONFIG_DIR.format(osd_id), raw=True)
 
         osd.delete()
         node.invalidate_dynamics()

--- a/ovs/lib/albanodecluster.py
+++ b/ovs/lib/albanodecluster.py
@@ -31,7 +31,7 @@ from ovs.extensions.generic.sshclient import UnableToConnectException
 from ovs_extensions.generic.toolbox import ExtensionsToolbox
 from ovs.lib.alba import AlbaController
 from ovs.lib.disk import DiskController
-from ovs.lib.shared.albanode import constants
+from ovs.constants.albanode import ASD_CONFIG, ASD_CONFIG_DIR
 from ovs.lib.helpers.decorators import ovs_task
 
 
@@ -312,8 +312,8 @@ class AlbaNodeClusterController(object):
                     AlbaNodeClusterController._logger.exception('Error while syncing stacks to the passive side')
 
         # Clean configuration management and model - Well, just try it at least
-        if Configuration.exists(constants.ASD_CONFIG.format(osd_id), raw=True):
-            Configuration.delete(constants.ASD_CONFIG_DIR.format(osd_id), raw=True)
+        if Configuration.exists(ASD_CONFIG.format(osd_id), raw=True):
+            Configuration.delete(ASD_CONFIG_DIR.format(osd_id), raw=True)
 
         osd.delete()
         active_node.invalidate_dynamics()


### PR DESCRIPTION
Due to absence of the constants folder in ovs.constants, freshly installed environments lacked the albaplugin constants. Adding this folder to core ovs sovles this problem.